### PR TITLE
Add sudosh recording command and embed export script in agent

### DIFF
--- a/cmd/command/handler.go
+++ b/cmd/command/handler.go
@@ -18,6 +18,8 @@ func NewCommandCommand(verbose *bool, configPath *string) *cobra.Command {
 		action    string
 		requestID string
 		publicKey string
+		startTime string
+		endTime   string
 		sudo      bool
 		dryRun    bool
 	)
@@ -31,7 +33,7 @@ without needing a full P0 backend connection.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCommand(
 				*verbose, *configPath,
-				command, userName, action, requestID, publicKey, sudo, dryRun,
+				command, userName, action, requestID, publicKey, startTime, endTime, sudo, dryRun,
 			)
 		},
 	}
@@ -41,6 +43,8 @@ without needing a full P0 backend connection.`,
 	cmd.Flags().StringVar(&action, "action", "grant", "Action to perform (grant or revoke)")
 	cmd.Flags().StringVar(&requestID, "request-id", "", "Request ID for tracking (auto-generated if empty)")
 	cmd.Flags().StringVar(&publicKey, "public-key", "", "SSH public key for authorized keys operations")
+	cmd.Flags().StringVar(&startTime, "start-time", "", "Start time filter (unix timestamp or ISO 8601)")
+	cmd.Flags().StringVar(&endTime, "end-time", "", "End time filter (unix timestamp or ISO 8601)")
 	cmd.Flags().BoolVar(&sudo, "sudo", false, "Grant sudo access")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Log commands but don't execute them (safe testing mode)")
 
@@ -52,7 +56,7 @@ without needing a full P0 backend connection.`,
 
 func runCommand(
 	verbose bool, configPath string,
-	command, userName, action, requestID, publicKey string, sudo, dryRun bool,
+	command, userName, action, requestID, publicKey, startTime, endTime string, sudo, dryRun bool,
 ) error {
 	logger := logrus.New()
 	if verbose {
@@ -73,17 +77,19 @@ func runCommand(
 		"sudo":       sudo,
 		"dry_run":    dryRun,
 		"has_key":    publicKey != "",
-	}).Info("🧪 Executing provisioning command")
+	}).Info("Executing provisioning command")
 
 	req := scripts.ProvisioningRequest{
 		UserName:  userName,
 		Action:    action,
 		RequestID: requestID,
 		PublicKey: publicKey,
+		StartTime: startTime,
+		EndTime:   endTime,
 		Sudo:      sudo,
 	}
 
-	fmt.Println("📋 Provisioning Request:")
+	fmt.Println("Provisioning Request:")
 	fmt.Println("=" + strings.Repeat("=", 30))
 	requestJSON, _ := json.MarshalIndent(req, "", "  ")
 	fmt.Println(string(requestJSON))
@@ -91,18 +97,18 @@ func runCommand(
 
 	result := scripts.ExecuteScript(command, req, dryRun, logger)
 
-	fmt.Println("\n📊 Execution Result:")
+	fmt.Println("\nExecution Result:")
 	fmt.Println("=" + strings.Repeat("=", 25))
 	resultJSON, _ := json.MarshalIndent(result, "", "  ")
 	fmt.Println(string(resultJSON))
 
 	if result.Success {
-		fmt.Println("\n✅ Command executed successfully!")
+		fmt.Println("\nCommand executed successfully!")
 		if dryRun {
-			fmt.Println("🔍 DRY-RUN: No actual changes were made to the system")
+			fmt.Println("DRY-RUN: No actual changes were made to the system")
 		}
 	} else {
-		fmt.Println("\n❌ Command execution failed!")
+		fmt.Println("\nCommand execution failed!")
 		fmt.Printf("Error: %s\n", result.Error)
 		return fmt.Errorf("command execution failed: %s", result.Error)
 	}

--- a/scripts/collect_sudosh_recordings.go
+++ b/scripts/collect_sudosh_recordings.go
@@ -3,9 +3,13 @@ package scripts
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -14,6 +18,24 @@ import (
 const (
 	recordingsCollectionTimeout = 2 * time.Minute
 )
+
+type auditEventRow struct {
+	ID        string      `json:"id"`
+	Timestamp string      `json:"timestamp"`
+	Action    string      `json:"action,omitempty"`
+	Actor     string      `json:"actor,omitempty"`
+	Target    string      `json:"target,omitempty"`
+	Summary   string      `json:"summary"`
+	Details   interface{} `json:"details,omitempty"`
+	Severity  string      `json:"severity,omitempty"`
+	Raw       interface{} `json:"raw,omitempty"`
+}
+
+type sudoshExportSession struct {
+	sessionID   string
+	scriptLines []string
+	timingLines []string
+}
 
 const collectSudoshRecordingsScript = `#!/bin/bash
 set -e
@@ -183,9 +205,236 @@ func CollectSudoshRecordings(req ProvisioningRequest, logger *logrus.Logger) Pro
 	}
 
 	logger.WithField("username", req.UserName).Info("Sudosh recordings collected successfully")
+
+	augmentedOutput, err := appendAuditEventsToSudoshExport(stdout.String(), req.UserName)
+	if err != nil {
+		logger.WithError(err).Warn("Failed to derive audit events from sudosh export; returning playback payload only")
+		augmentedOutput = stdout.String()
+	}
+
 	return ProvisioningResult{
 		Success: true,
 		Message: "Sudosh recordings collected successfully",
-		Output:  stdout.String(),
+		Output:  augmentedOutput,
 	}
+}
+
+func appendAuditEventsToSudoshExport(output, username string) (string, error) {
+	lines := strings.Split(output, "\n")
+	var rebuilt []string
+
+	for index := 0; index < len(lines); index++ {
+		line := lines[index]
+		if line != "=== SESSION_START ===" {
+			rebuilt = append(rebuilt, line)
+			continue
+		}
+
+		session, nextIndex, err := parseSudoshSessionBlock(lines, index)
+		if err != nil {
+			return "", err
+		}
+
+		events, err := deriveAuditEvents(session, username)
+		if err != nil {
+			return "", err
+		}
+
+		eventsJSON, err := json.Marshal(events)
+		if err != nil {
+			return "", fmt.Errorf("marshal audit events for %s: %w", session.sessionID, err)
+		}
+
+		rebuilt = append(rebuilt, "=== SESSION_START ===")
+		rebuilt = append(rebuilt, fmt.Sprintf("SESSION_ID: %s", session.sessionID))
+		rebuilt = append(rebuilt, "SCRIPT_BASE64:")
+		rebuilt = append(rebuilt, session.scriptLines...)
+		rebuilt = append(rebuilt, "TIMING_BASE64:")
+		rebuilt = append(rebuilt, session.timingLines...)
+		rebuilt = append(rebuilt, "AUDIT_EVENTS_JSON:")
+		rebuilt = append(rebuilt, string(eventsJSON))
+		rebuilt = append(rebuilt, "=== SESSION_END ===")
+
+		index = nextIndex
+	}
+
+	return strings.Join(rebuilt, "\n"), nil
+}
+
+func parseSudoshSessionBlock(lines []string, start int) (sudoshExportSession, int, error) {
+	session := sudoshExportSession{}
+	state := ""
+
+	for index := start + 1; index < len(lines); index++ {
+		line := lines[index]
+
+		switch {
+		case strings.HasPrefix(line, "SESSION_ID: "):
+			session.sessionID = strings.TrimPrefix(line, "SESSION_ID: ")
+		case line == "SCRIPT_BASE64:":
+			state = "script"
+		case line == "TIMING_BASE64:":
+			state = "timing"
+		case line == "=== SESSION_END ===":
+			if session.sessionID == "" {
+				return sudoshExportSession{}, 0, fmt.Errorf("missing SESSION_ID in sudosh export")
+			}
+			return session, index, nil
+		default:
+			switch state {
+			case "script":
+				if line != "" {
+					session.scriptLines = append(session.scriptLines, line)
+				}
+			case "timing":
+				if line != "" {
+					session.timingLines = append(session.timingLines, line)
+				}
+			}
+		}
+	}
+
+	return sudoshExportSession{}, 0, fmt.Errorf("unterminated session block in sudosh export")
+}
+
+func deriveAuditEvents(session sudoshExportSession, username string) ([]auditEventRow, error) {
+	scriptBytes, err := base64.StdEncoding.DecodeString(strings.Join(session.scriptLines, ""))
+	if err != nil {
+		return nil, fmt.Errorf("decode script for %s: %w", session.sessionID, err)
+	}
+
+	timingBytes, err := base64.StdEncoding.DecodeString(strings.Join(session.timingLines, ""))
+	if err != nil {
+		return nil, fmt.Errorf("decode timing for %s: %w", session.sessionID, err)
+	}
+
+	startTime := parseSessionStartTime(session.sessionID)
+	duration := parseSessionDuration(string(timingBytes))
+	endTime := startTime.Add(duration)
+
+	var events []auditEventRow
+	events = append(events, auditEventRow{
+		ID:        fmt.Sprintf("%s-start", session.sessionID),
+		Timestamp: startTime.Format(time.RFC3339),
+		Action:    "session.started",
+		Actor:     username,
+		Target:    session.sessionID,
+		Summary:   "SSH session recording started",
+		Details: map[string]interface{}{
+			"sessionId": session.sessionID,
+		},
+		Severity: "info",
+		Raw: map[string]interface{}{
+			"sessionId": session.sessionID,
+		},
+	})
+
+	commandLines := extractCommandLines(string(scriptBytes))
+	commandCount := len(commandLines)
+	for index, commandLine := range commandLines {
+		commandTimestamp := startTime
+		if duration > 0 && commandCount > 0 {
+			offset := time.Duration(float64(duration) * float64(index+1) / float64(commandCount+1))
+			commandTimestamp = startTime.Add(offset)
+		}
+
+		events = append(events, auditEventRow{
+			ID:        fmt.Sprintf("%s-command-%d", session.sessionID, index),
+			Timestamp: commandTimestamp.Format(time.RFC3339),
+			Action:    "terminal.command",
+			Actor:     username,
+			Target:    session.sessionID,
+			Summary:   fmt.Sprintf("Command executed: %s", commandLine),
+			Details: map[string]interface{}{
+				"command":   commandLine,
+				"sessionId": session.sessionID,
+				"index":     index,
+			},
+			Severity: "info",
+			Raw: map[string]interface{}{
+				"line": commandLine,
+			},
+		})
+	}
+
+	events = append(events, auditEventRow{
+		ID:        fmt.Sprintf("%s-end", session.sessionID),
+		Timestamp: endTime.Format(time.RFC3339),
+		Action:    "session.ended",
+		Actor:     username,
+		Target:    session.sessionID,
+		Summary:   "SSH session recording ended",
+		Details: map[string]interface{}{
+			"sessionId":       session.sessionID,
+			"durationSeconds": duration.Seconds(),
+		},
+		Severity: "info",
+		Raw: map[string]interface{}{
+			"sessionId": session.sessionID,
+		},
+	})
+
+	return events, nil
+}
+
+func parseSessionStartTime(sessionID string) time.Time {
+	marker := strings.LastIndex(sessionID, "-script-")
+	if marker == -1 {
+		return time.Now().UTC()
+	}
+
+	suffix := sessionID[marker+len("-script-"):]
+	timestampToken := strings.SplitN(suffix, "-", 2)[0]
+	seconds, err := strconv.ParseInt(timestampToken, 10, 64)
+	if err != nil {
+		return time.Now().UTC()
+	}
+
+	return time.Unix(seconds, 0).UTC()
+}
+
+func parseSessionDuration(timingOutput string) time.Duration {
+	var totalSeconds float64
+	for _, line := range strings.Split(timingOutput, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		delaySeconds, err := strconv.ParseFloat(fields[0], 64)
+		if err != nil {
+			continue
+		}
+		totalSeconds += delaySeconds
+	}
+
+	return time.Duration(totalSeconds * float64(time.Second))
+}
+
+func extractCommandLines(scriptOutput string) []string {
+	var commands []string
+
+	for _, line := range strings.Split(strings.ReplaceAll(scriptOutput, "\r", ""), "\n") {
+		cleanedLine := strings.TrimSpace(line)
+		if cleanedLine == "" {
+			continue
+		}
+
+		if marker := strings.LastIndex(cleanedLine, "$ "); marker != -1 {
+			command := strings.TrimSpace(cleanedLine[marker+2:])
+			if command != "" {
+				commands = append(commands, command)
+			}
+			continue
+		}
+
+		if marker := strings.LastIndex(cleanedLine, "# "); marker != -1 {
+			command := strings.TrimSpace(cleanedLine[marker+2:])
+			if command != "" {
+				commands = append(commands, command)
+			}
+		}
+	}
+
+	return commands
 }

--- a/scripts/collect_sudosh_recordings.go
+++ b/scripts/collect_sudosh_recordings.go
@@ -12,9 +12,126 @@ import (
 )
 
 const (
-	retrieveRecordingsScriptPath = "/usr/local/bin/retrieve-recordings.sh"
-	recordingsCollectionTimeout  = 2 * time.Minute
+	recordingsCollectionTimeout = 2 * time.Minute
 )
+
+const collectSudoshRecordingsScript = `#!/bin/bash
+set -e
+
+LOG_DIR="/var/log/sudosh"
+
+USERNAME="${USERNAME:-}"
+START_TIME="${START_TIME:-}"
+END_TIME="${END_TIME:-}"
+
+echo "=== Exporting sudosh session recordings ==="
+
+if [ -z "$USERNAME" ]; then
+    echo "ERROR: USERNAME environment variable is required"
+    exit 1
+fi
+
+if [ ! -d "$LOG_DIR" ]; then
+    echo "ERROR: Log directory $LOG_DIR does not exist"
+    exit 1
+fi
+
+parse_timestamp() {
+    local input="$1"
+
+    if [[ "$input" =~ ^[0-9]+$ ]]; then
+        echo "$input"
+        return
+    fi
+
+    if date --version >/dev/null 2>&1; then
+        date -d "$input" +%s 2>/dev/null || echo "0"
+    else
+        date -j -f "%Y-%m-%dT%H:%M:%SZ" "$input" +%s 2>/dev/null || echo "0"
+    fi
+}
+
+if [ -n "$START_TIME" ]; then
+    START_TIMESTAMP=$(parse_timestamp "$START_TIME")
+else
+    START_TIMESTAMP=0
+fi
+
+if [ -n "$END_TIME" ]; then
+    END_TIMESTAMP=$(parse_timestamp "$END_TIME")
+else
+    END_TIMESTAMP=9999999999
+fi
+
+echo "Searching for recordings:"
+echo "  Username: $USERNAME"
+echo "  Start time: $START_TIME (timestamp: $START_TIMESTAMP)"
+echo "  End time: $END_TIME (timestamp: $END_TIMESTAMP)"
+echo ""
+
+extract_session_timestamp() {
+    local filename="$1"
+    local prefix="${filename%-script-*}"
+    local suffix="${filename#${prefix}-script-}"
+    local timestamp=$(echo "$suffix" | cut -d'-' -f1)
+    echo "$timestamp"
+}
+
+cd "$LOG_DIR"
+
+matching_sessions=()
+
+shopt -s nullglob
+for script_file in ${USERNAME}-*-script-*; do
+    if [ -f "$script_file" ]; then
+        session_id="${script_file%-script-*}"
+        suffix="${script_file#*-script-}"
+        timing_file="${session_id}-time-${suffix}"
+
+        if [ ! -f "$timing_file" ]; then
+            echo "WARNING: Timing file missing for ${session_id}-time-${suffix}, skipping"
+            continue
+        fi
+
+        file_timestamp=$(extract_session_timestamp "$script_file")
+
+        if [ "$file_timestamp" -ge "$START_TIMESTAMP" ] && [ "$file_timestamp" -le "$END_TIMESTAMP" ]; then
+            matching_sessions+=("$script_file")
+        fi
+    fi
+done
+
+echo "Found ${#matching_sessions[@]} matching session(s)"
+echo ""
+
+if [ ${#matching_sessions[@]} -eq 0 ]; then
+    echo "No recordings found matching criteria"
+    exit 0
+fi
+
+echo "=== EXPORT_START ==="
+echo "SESSIONS_COUNT: ${#matching_sessions[@]}"
+echo ""
+
+for script_file in "${matching_sessions[@]}"; do
+    session_id="${script_file%-script-*}"
+    suffix="${script_file#*-script-}"
+    timing_file="${session_id}-time-${suffix}"
+
+    echo "=== SESSION_START ==="
+    echo "SESSION_ID: ${script_file}"
+    echo "SCRIPT_BASE64:"
+    base64 < "$script_file"
+    echo "TIMING_BASE64:"
+    base64 < "$timing_file"
+    echo "=== SESSION_END ==="
+    echo ""
+done
+
+echo "=== EXPORT_END ==="
+echo ""
+echo "=== Export Complete ==="
+`
 
 // CollectSudoshRecordings exports sudosh recordings for a user and optional time range.
 func CollectSudoshRecordings(req ProvisioningRequest, logger *logrus.Logger) ProvisioningResult {
@@ -34,7 +151,7 @@ func CollectSudoshRecordings(req ProvisioningRequest, logger *logrus.Logger) Pro
 	ctx, cancel := context.WithTimeout(context.Background(), recordingsCollectionTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, retrieveRecordingsScriptPath)
+	cmd := exec.CommandContext(ctx, "bash", "-c", collectSudoshRecordingsScript)
 	cmd.Env = append(os.Environ(),
 		fmt.Sprintf("USERNAME=%s", req.UserName),
 		fmt.Sprintf("START_TIME=%s", req.StartTime),

--- a/scripts/collect_sudosh_recordings.go
+++ b/scripts/collect_sudosh_recordings.go
@@ -8,12 +8,23 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
 )
+
+var validTimestampPattern = regexp.MustCompile(`^[0-9]+$`)
+var validISO8601Pattern = regexp.MustCompile(`^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$`)
+
+func isValidTimestamp(ts string) bool {
+	if ts == "" {
+		return true
+	}
+	return validTimestampPattern.MatchString(ts) || validISO8601Pattern.MatchString(ts)
+}
 
 const (
 	recordingsCollectionTimeout = 2 * time.Minute
@@ -170,6 +181,20 @@ func CollectSudoshRecordings(req ProvisioningRequest, logger *logrus.Logger) Pro
 		}
 	}
 
+	if !isValidTimestamp(req.StartTime) {
+		return ProvisioningResult{
+			Success: false,
+			Error:   fmt.Sprintf("invalid startTime format %q: must be a unix timestamp or ISO 8601 (e.g. 2024-01-01T00:00:00Z)", req.StartTime),
+		}
+	}
+
+	if !isValidTimestamp(req.EndTime) {
+		return ProvisioningResult{
+			Success: false,
+			Error:   fmt.Sprintf("invalid endTime format %q: must be a unix timestamp or ISO 8601 (e.g. 2024-01-01T00:00:00Z)", req.EndTime),
+		}
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), recordingsCollectionTimeout)
 	defer cancel()
 
@@ -308,7 +333,10 @@ func deriveAuditEvents(session sudoshExportSession, username string) ([]auditEve
 		return nil, fmt.Errorf("decode timing for %s: %w", session.sessionID, err)
 	}
 
-	startTime := parseSessionStartTime(session.sessionID)
+	startTime, err := parseSessionStartTime(session.sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("parse start time for %s: %w", session.sessionID, err)
+	}
 	duration := parseSessionDuration(string(timingBytes))
 	endTime := startTime.Add(duration)
 
@@ -377,20 +405,20 @@ func deriveAuditEvents(session sudoshExportSession, username string) ([]auditEve
 	return events, nil
 }
 
-func parseSessionStartTime(sessionID string) time.Time {
+func parseSessionStartTime(sessionID string) (time.Time, error) {
 	marker := strings.LastIndex(sessionID, "-script-")
 	if marker == -1 {
-		return time.Now().UTC()
+		return time.Time{}, fmt.Errorf("session ID %q missing -script- marker", sessionID)
 	}
 
 	suffix := sessionID[marker+len("-script-"):]
 	timestampToken := strings.SplitN(suffix, "-", 2)[0]
 	seconds, err := strconv.ParseInt(timestampToken, 10, 64)
 	if err != nil {
-		return time.Now().UTC()
+		return time.Time{}, fmt.Errorf("parse timestamp from session ID %q: %w", sessionID, err)
 	}
 
-	return time.Unix(seconds, 0).UTC()
+	return time.Unix(seconds, 0).UTC(), nil
 }
 
 func parseSessionDuration(timingOutput string) time.Duration {

--- a/scripts/collect_sudosh_recordings.go
+++ b/scripts/collect_sudosh_recordings.go
@@ -1,0 +1,74 @@
+package scripts
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	retrieveRecordingsScriptPath = "/usr/local/bin/retrieve-recordings.sh"
+	recordingsCollectionTimeout  = 2 * time.Minute
+)
+
+// CollectSudoshRecordings exports sudosh recordings for a user and optional time range.
+func CollectSudoshRecordings(req ProvisioningRequest, logger *logrus.Logger) ProvisioningResult {
+	logger.WithFields(logrus.Fields{
+		"username":   req.UserName,
+		"start_time": req.StartTime,
+		"end_time":   req.EndTime,
+	}).Info("Collecting sudosh recordings")
+
+	if !isValidUsername(req.UserName) {
+		return ProvisioningResult{
+			Success: false,
+			Error:   "invalid username format: must match ^[a-z][-a-z0-9_]*$",
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), recordingsCollectionTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, retrieveRecordingsScriptPath)
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("USERNAME=%s", req.UserName),
+		fmt.Sprintf("START_TIME=%s", req.StartTime),
+		fmt.Sprintf("END_TIME=%s", req.EndTime),
+	)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			logger.Error("Sudosh recordings export timed out")
+			return ProvisioningResult{
+				Success: false,
+				Error:   fmt.Sprintf("recordings export timed out after %s", recordingsCollectionTimeout),
+			}
+		}
+
+		logger.WithFields(logrus.Fields{
+			"error":  err.Error(),
+			"stderr": stderr.String(),
+		}).Error("Sudosh recordings export failed")
+
+		return ProvisioningResult{
+			Success: false,
+			Error:   fmt.Sprintf("failed to collect sudosh recordings: %v: %s", err, stderr.String()),
+		}
+	}
+
+	logger.WithField("username", req.UserName).Info("Sudosh recordings collected successfully")
+	return ProvisioningResult{
+		Success: true,
+		Message: "Sudosh recordings collected successfully",
+		Output:  stdout.String(),
+	}
+}

--- a/scripts/collect_sudosh_recordings_test.go
+++ b/scripts/collect_sudosh_recordings_test.go
@@ -1,0 +1,108 @@
+package scripts
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAppendAuditEventsToSudoshExport(t *testing.T) {
+	t.Parallel()
+
+	sessionID := "alice-alice-script-1710000000-testsession"
+	scriptOutput := strings.Join([]string{
+		"Aarons-MacBook-Pro:~ alice$ echo hello",
+		"hello",
+		"Aarons-MacBook-Pro:~ alice$ pwd",
+		"/Users/alice",
+	}, "\r\n")
+	timingOutput := strings.Join([]string{
+		"1.0 10",
+		"1.0 10",
+	}, "\n")
+
+	exportPayload := strings.Join([]string{
+		"=== Exporting sudosh session recordings ===",
+		"=== EXPORT_START ===",
+		"SESSIONS_COUNT: 1",
+		"",
+		"=== SESSION_START ===",
+		"SESSION_ID: " + sessionID,
+		"SCRIPT_BASE64:",
+		base64.StdEncoding.EncodeToString([]byte(scriptOutput)),
+		"TIMING_BASE64:",
+		base64.StdEncoding.EncodeToString([]byte(timingOutput)),
+		"=== SESSION_END ===",
+		"",
+		"=== EXPORT_END ===",
+	}, "\n")
+
+	augmentedOutput, err := appendAuditEventsToSudoshExport(exportPayload, "alice")
+	if err != nil {
+		t.Fatalf("appendAuditEventsToSudoshExport returned error: %v", err)
+	}
+
+	if !strings.Contains(augmentedOutput, "AUDIT_EVENTS_JSON:") {
+		t.Fatalf("expected augmented output to contain AUDIT_EVENTS_JSON section, got:\n%s", augmentedOutput)
+	}
+
+	eventsJSON := lineAfterMarker(t, augmentedOutput, "AUDIT_EVENTS_JSON:")
+
+	var events []auditEventRow
+	if err := json.Unmarshal([]byte(eventsJSON), &events); err != nil {
+		t.Fatalf("failed to unmarshal audit events JSON: %v", err)
+	}
+
+	if len(events) != 4 {
+		t.Fatalf("expected 4 audit events, got %d", len(events))
+	}
+
+	if events[0].Action != "session.started" {
+		t.Fatalf("expected first event to be session.started, got %q", events[0].Action)
+	}
+	if events[1].Action != "terminal.command" || events[1].Summary != "Command executed: echo hello" {
+		t.Fatalf("unexpected first command event: %#v", events[1])
+	}
+	if events[2].Action != "terminal.command" || events[2].Summary != "Command executed: pwd" {
+		t.Fatalf("unexpected second command event: %#v", events[2])
+	}
+	if events[3].Action != "session.ended" {
+		t.Fatalf("expected final event to be session.ended, got %q", events[3].Action)
+	}
+
+	expectedStart := time.Unix(1710000000, 0).UTC().Format(time.RFC3339)
+	expectedEnd := time.Unix(1710000000, 0).UTC().Add(2 * time.Second).Format(time.RFC3339)
+
+	if events[0].Timestamp != expectedStart {
+		t.Fatalf("expected session start timestamp %q, got %q", expectedStart, events[0].Timestamp)
+	}
+	if events[3].Timestamp != expectedEnd {
+		t.Fatalf("expected session end timestamp %q, got %q", expectedEnd, events[3].Timestamp)
+	}
+
+	if !strings.Contains(augmentedOutput, base64.StdEncoding.EncodeToString([]byte(scriptOutput))) {
+		t.Fatal("expected script playback payload to be preserved in augmented output")
+	}
+	if !strings.Contains(augmentedOutput, base64.StdEncoding.EncodeToString([]byte(timingOutput))) {
+		t.Fatal("expected timing playback payload to be preserved in augmented output")
+	}
+}
+
+func lineAfterMarker(t *testing.T, body, marker string) string {
+	t.Helper()
+
+	lines := strings.Split(body, "\n")
+	for index, line := range lines {
+		if line == marker {
+			if index+1 >= len(lines) {
+				t.Fatalf("marker %q found without following line", marker)
+			}
+			return lines[index+1]
+		}
+	}
+
+	t.Fatalf("marker %q not found in body", marker)
+	return ""
+}

--- a/scripts/shared.go
+++ b/scripts/shared.go
@@ -199,7 +199,7 @@ func ExecuteScript(command string, data interface{}, dryRun bool, logger *logrus
 			"username": req.UserName,
 			"action":   req.Action,
 		}).Info("🔍 DRY-RUN: Would execute provisioning script (no actual changes made)")
-		
+
 		return ProvisioningResult{
 			Success: true,
 			Message: fmt.Sprintf("DRY-RUN: Would execute %s for user %s", command, req.UserName),
@@ -209,6 +209,8 @@ func ExecuteScript(command string, data interface{}, dryRun bool, logger *logrus
 	switch Command(command) {
 	case CommandRunAudit:
 		return RunAudit(logger)
+	case CommandCollectSudoshRecordings:
+		return CollectSudoshRecordings(req, logger)
 	case CommandProvisionUser:
 		return ProvisionUser(req, logger)
 	case CommandProvisionAuthorizedKeys:

--- a/scripts/types.go
+++ b/scripts/types.go
@@ -1,12 +1,14 @@
 package scripts
 
 type ProvisioningRequest struct {
-	UserName     string `json:"userName"`
-	Action       string `json:"action"`
-	RequestID    string `json:"requestId"`
-	PublicKey    string `json:"publicKey,omitempty"`
-	CAPublicKey  string `json:"caPublicKey,omitempty"`
-	Sudo         bool   `json:"sudo,omitempty"`
+	UserName    string `json:"userName"`
+	Action      string `json:"action"`
+	RequestID   string `json:"requestId"`
+	StartTime   string `json:"startTime,omitempty"`
+	EndTime     string `json:"endTime,omitempty"`
+	PublicKey   string `json:"publicKey,omitempty"`
+	CAPublicKey string `json:"caPublicKey,omitempty"`
+	Sudo        bool   `json:"sudo,omitempty"`
 }
 
 type ProvisioningResult struct {
@@ -25,4 +27,5 @@ const (
 	CommandProvisionSudo           Command = "provisionSudo"
 	CommandProvisionSession        Command = "provisionSession"
 	CommandRunAudit                Command = "runAudit"
+	CommandCollectSudoshRecordings Command = "collectSudoshRecordings"
 )


### PR DESCRIPTION
**Problem**

The agent has no way to export sudosh session recordings for a user, which is needed for IAM assessment workflows. There is also no structured audit trail derived from the raw recordings.

**Change**

- Add a `collectSudoshRecordings` command that runs an embedded bash script (based off of `retrieve-recordings.sh` script) to export sudosh session recordings (base64-encoded script + timing files) filtered by username and optional time range
- Parse the export output and augment each session with derived audit events (session start/end, extracted commands with interpolated timestamps)
- Wire the new command into the `ExecuteScript` dispatch
- Add `StartTime`/`EndTime` fields to `ProvisioningRequest`
- Validate `StartTime`/`EndTime` inputs in Go before passing to the shell script (must be unix timestamp or ISO 8601)
- Change `parseSessionStartTime` to return an error instead of silently falling back to time.Now()

**Validation**

- go vet ./scripts/ passes
- TestAppendAuditEventsToSudoshExport covers the round-trip: encode -> export format -> augment -> verify event count, types, ordering, timestamps, and preserved payloads