### PR TITLE
Fix sudosh session evidence parsing

### DIFF
--- a/scripts/collect_sudosh_recordings.go
+++ b/scripts/collect_sudosh_recordings.go
@@ -17,14 +17,8 @@ import (
 )
 
 var validTimestampPattern = regexp.MustCompile(`^[0-9]+$`)
-var validISO8601Pattern = regexp.MustCompile(`^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$`)
-
-func isValidTimestamp(ts string) bool {
-	if ts == "" {
-		return true
-	}
-	return validTimestampPattern.MatchString(ts) || validISO8601Pattern.MatchString(ts)
-}
+var oscSequencePattern = regexp.MustCompile("\x1b\\][^\x07\x1b]*(?:\x07|\x1b\\\\)")
+var ansiEscapePattern = regexp.MustCompile("\x1b\\[[0-9;?]*[ -/]*[@-~]")
 
 const (
 	recordingsCollectionTimeout = 2 * time.Minute
@@ -195,14 +189,17 @@ func CollectSudoshRecordings(req ProvisioningRequest, logger *logrus.Logger) Pro
 		}
 	}
 
+	normalizedStartTime, _ := normalizeTimestampForShell(req.StartTime)
+	normalizedEndTime, _ := normalizeTimestampForShell(req.EndTime)
+
 	ctx, cancel := context.WithTimeout(context.Background(), recordingsCollectionTimeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "bash", "-c", collectSudoshRecordingsScript)
 	cmd.Env = append(os.Environ(),
 		fmt.Sprintf("USERNAME=%s", req.UserName),
-		fmt.Sprintf("START_TIME=%s", req.StartTime),
-		fmt.Sprintf("END_TIME=%s", req.EndTime),
+		fmt.Sprintf("START_TIME=%s", normalizedStartTime),
+		fmt.Sprintf("END_TIME=%s", normalizedEndTime),
 	)
 
 	var stdout, stderr bytes.Buffer
@@ -338,6 +335,11 @@ func deriveAuditEvents(session sudoshExportSession, username string) ([]auditEve
 		return nil, fmt.Errorf("parse start time for %s: %w", session.sessionID, err)
 	}
 	duration := parseSessionDuration(string(timingBytes))
+	commandLines := extractCommandLines(string(scriptBytes))
+	if len(commandLines) == 0 {
+		return []auditEventRow{}, nil
+	}
+
 	endTime := startTime.Add(duration)
 
 	var events []auditEventRow
@@ -357,7 +359,6 @@ func deriveAuditEvents(session sudoshExportSession, username string) ([]auditEve
 		},
 	})
 
-	commandLines := extractCommandLines(string(scriptBytes))
 	commandCount := len(commandLines)
 	for index, commandLine := range commandLines {
 		commandTimestamp := startTime
@@ -405,6 +406,30 @@ func deriveAuditEvents(session sudoshExportSession, username string) ([]auditEve
 	return events, nil
 }
 
+func isValidTimestamp(ts string) bool {
+	if ts == "" {
+		return true
+	}
+	_, err := normalizeTimestampForShell(ts)
+	return err == nil
+}
+
+func normalizeTimestampForShell(ts string) (string, error) {
+	if ts == "" {
+		return "", nil
+	}
+	if validTimestampPattern.MatchString(ts) {
+		return ts, nil
+	}
+
+	parsed, err := time.Parse(time.RFC3339Nano, ts)
+	if err != nil {
+		return "", err
+	}
+
+	return strconv.FormatInt(parsed.Unix(), 10), nil
+}
+
 func parseSessionStartTime(sessionID string) (time.Time, error) {
 	marker := strings.LastIndex(sessionID, "-script-")
 	if marker == -1 {
@@ -443,26 +468,84 @@ func extractCommandLines(scriptOutput string) []string {
 	var commands []string
 
 	for _, line := range strings.Split(strings.ReplaceAll(scriptOutput, "\r", ""), "\n") {
-		cleanedLine := strings.TrimSpace(line)
-		if cleanedLine == "" {
-			continue
-		}
-
-		if marker := strings.LastIndex(cleanedLine, "$ "); marker != -1 {
-			command := strings.TrimSpace(cleanedLine[marker+2:])
-			if command != "" {
-				commands = append(commands, command)
-			}
-			continue
-		}
-
-		if marker := strings.LastIndex(cleanedLine, "# "); marker != -1 {
-			command := strings.TrimSpace(cleanedLine[marker+2:])
-			if command != "" {
-				commands = append(commands, command)
-			}
+		command, ok := extractCommandLine(line)
+		if ok {
+			commands = append(commands, command)
 		}
 	}
 
 	return commands
+}
+
+func extractCommandLine(line string) (string, bool) {
+	cleanedLine := sanitizeTerminalLine(line)
+	if cleanedLine == "" {
+		return "", false
+	}
+
+	for _, marker := range []string{"$ ", "# "} {
+		promptIndex := strings.LastIndex(cleanedLine, marker)
+		if promptIndex == -1 {
+			continue
+		}
+
+		command := strings.TrimSpace(cleanedLine[promptIndex+len(marker):])
+		if command == "" {
+			return "", false
+		}
+
+		command = strings.Join(strings.Fields(command), " ")
+		if command == "" || looksLikePrompt(command) {
+			return "", false
+		}
+
+		return command, true
+	}
+
+	return "", false
+}
+
+func sanitizeTerminalLine(line string) string {
+	line = oscSequencePattern.ReplaceAllString(line, "")
+	line = ansiEscapePattern.ReplaceAllString(line, "")
+	line = collapseBackspaces(line)
+	line = strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			if r == ' ' || r == '\t' {
+				return ' '
+			}
+			return -1
+		}
+		return r
+	}, line)
+	return strings.TrimSpace(line)
+}
+
+func collapseBackspaces(line string) string {
+	buf := make([]rune, 0, len(line))
+	for _, r := range line {
+		if r == '\b' {
+			if len(buf) > 0 {
+				buf = buf[:len(buf)-1]
+			}
+			continue
+		}
+		buf = append(buf, r)
+	}
+	return string(buf)
+}
+
+func looksLikePrompt(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return true
+	}
+
+	for _, suffix := range []string{"$", "#"} {
+		if strings.HasSuffix(trimmed, suffix) && strings.Contains(trimmed, "@") {
+			return true
+		}
+	}
+
+	return false
 }

--- a/scripts/collect_sudosh_recordings_test.go
+++ b/scripts/collect_sudosh_recordings_test.go
@@ -90,6 +90,86 @@ func TestAppendAuditEventsToSudoshExport(t *testing.T) {
 	}
 }
 
+func TestAppendAuditEventsToSudoshExportSkipsSyntheticLifecycleWithoutCommands(t *testing.T) {
+	t.Parallel()
+
+	sessionID := "alice-alice-script-1710000000-testsession"
+	scriptOutput := strings.Join([]string{
+		"\u001b]0;alice@host: ~\u0007alice@host:~$",
+		"\u001b]0;alice@host: ~\u0007alice@host:~$",
+	}, "\r\n")
+	timingOutput := "1.0 10\n"
+
+	exportPayload := strings.Join([]string{
+		"=== Exporting sudosh session recordings ===",
+		"=== EXPORT_START ===",
+		"SESSIONS_COUNT: 1",
+		"",
+		"=== SESSION_START ===",
+		"SESSION_ID: " + sessionID,
+		"SCRIPT_BASE64:",
+		base64.StdEncoding.EncodeToString([]byte(scriptOutput)),
+		"TIMING_BASE64:",
+		base64.StdEncoding.EncodeToString([]byte(timingOutput)),
+		"=== SESSION_END ===",
+		"",
+		"=== EXPORT_END ===",
+	}, "\n")
+
+	augmentedOutput, err := appendAuditEventsToSudoshExport(exportPayload, "alice")
+	if err != nil {
+		t.Fatalf("appendAuditEventsToSudoshExport returned error: %v", err)
+	}
+
+	eventsJSON := lineAfterMarker(t, augmentedOutput, "AUDIT_EVENTS_JSON:")
+
+	var events []auditEventRow
+	if err := json.Unmarshal([]byte(eventsJSON), &events); err != nil {
+		t.Fatalf("failed to unmarshal audit events JSON: %v", err)
+	}
+
+	if len(events) != 0 {
+		t.Fatalf("expected no audit events, got %#v", events)
+	}
+}
+
+func TestExtractCommandLinesSanitizesPromptNoise(t *testing.T) {
+	t.Parallel()
+
+	scriptOutput := strings.Join([]string{
+		"\u001b]0;aaron-keisler_p0@ip-172-31-31-167: ~\u0007aaron-keisler_p0@ip-172-31-31-167:~$",
+		"\u001b]0;aaron-keisler_p0@ip-172-31-31-167: ~\u0007aaron-keisler_p0@ip-172-31-31-167:~$ echo hello",
+		"root@ip-172-31-31-167:/#   df -h",
+		"\u001b[01;36mbin\u001b[0m",
+	}, "\n")
+
+	commands := extractCommandLines(scriptOutput)
+
+	expected := []string{"echo hello", "df -h"}
+	if len(commands) != len(expected) {
+		t.Fatalf("expected %d commands, got %#v", len(expected), commands)
+	}
+
+	for index, command := range expected {
+		if commands[index] != command {
+			t.Fatalf("expected command %d to be %q, got %q", index, command, commands[index])
+		}
+	}
+}
+
+func TestNormalizeTimestampForShellAcceptsFractionalISO8601(t *testing.T) {
+	t.Parallel()
+
+	normalized, err := normalizeTimestampForShell("2026-03-11T17:41:21.035Z")
+	if err != nil {
+		t.Fatalf("normalizeTimestampForShell returned error: %v", err)
+	}
+
+	if normalized != "1773250881" {
+		t.Fatalf("expected normalized timestamp to be %q, got %q", "1773250881", normalized)
+	}
+}
+
 func lineAfterMarker(t *testing.T, body, marker string) string {
 	t.Helper()
 


### PR DESCRIPTION
**Summary**

This updates `p0-agent`'s sudosh session evidence pipeline to be more resilient to real terminal output.

**Changes**

- accept fractional ISO 8601 timestamps for session evidence requests and normalize them before invoking the sudosh export script
- strip OSC/ANSI/control-sequence noise from sudosh script output before inferring `terminal.command` rows
- ignore prompt-only redraws so shell prompts are not emitted as fake commands
- suppress synthetic session lifecycle audit rows when a recording contains no real commands

**Why**

We were seeing two concrete issues in self-hosted session evidence:

1. session evidence requests could fail when `startTime` / `endTime` were passed as RFC3339 timestamps with fractional seconds
2. terminal prompt/title-update output such as `\u001b]0;...` and prompt redraws could be misclassified as `terminal.command` audit rows

This change makes the agent-side evidence payload cleaner and more robust without changing the recording payload itself.

**Validation**

- `go test ./scripts/...`